### PR TITLE
Test(Helpers): Add boolean-label and index-number coverage

### DIFF
--- a/tests/unit/helpers/boolean-label-test.js
+++ b/tests/unit/helpers/boolean-label-test.js
@@ -1,0 +1,17 @@
+import { module, test } from 'qunit';
+
+import { booleanLabel } from 'portfolio/helpers/boolean-label';
+
+module('Unit | Helper | boolean-label', function () {
+  test('it returns the truthy label when the condition is true', function (assert) {
+    const result = booleanLabel([true, 'yes', 'no']);
+
+    assert.strictEqual(result, 'yes');
+  });
+
+  test('it returns the falsy label when the condition is false', function (assert) {
+    const result = booleanLabel([false, 'yes', 'no']);
+
+    assert.strictEqual(result, 'no');
+  });
+});

--- a/tests/unit/helpers/index-number-test.js
+++ b/tests/unit/helpers/index-number-test.js
@@ -1,0 +1,15 @@
+import { module, test } from 'qunit';
+
+import { indexNumber } from 'portfolio/helpers/index-number';
+
+module('Unit | Helper | index-number', function () {
+  test('it pads single-digit indexes with a leading zero', function (assert) {
+    assert.strictEqual(indexNumber([0]), '01');
+    assert.strictEqual(indexNumber([8]), '09');
+  });
+
+  test('it does not pad double-digit indexes', function (assert) {
+    assert.strictEqual(indexNumber([9]), '10');
+    assert.strictEqual(indexNumber([10]), '11');
+  });
+});


### PR DESCRIPTION
Both helpers previously had zero coverage. Tests cover the
boolean-label truthy/falsy branch and the index-number
zero-padding boundary at the single/double-digit transition.

Co-Authored-By: Claude Sonnet 5 <noreply@anthropic.com>
Claude-Session: https://claude.ai/code/session_01L5K9Ao2SFn8V9hdGF9drYC