### PR TITLE
Test(Acceptance): Add projects and project detail coverage

### DIFF
--- a/tests/acceptance/projects-test.js
+++ b/tests/acceptance/projects-test.js
@@ -1,0 +1,45 @@
+import { currentURL, visit } from '@ember/test-helpers';
+import { module, test } from 'qunit';
+
+import { setupApplicationTest } from 'portfolio/tests/helpers';
+
+module('Acceptance | projects', function (hooks) {
+  setupApplicationTest(hooks);
+
+  test('visiting /projects renders the project list', async function (assert) {
+    await visit('/projects');
+
+    assert.strictEqual(
+      currentURL(),
+      '/projects',
+      'we are on the projects route',
+    );
+    assert
+      .dom(document.body)
+      .includesText('MINT EC', 'a known project title is rendered');
+  });
+
+  test('visiting /projects/:id renders the project detail', async function (assert) {
+    await visit('/projects/mint-ec');
+
+    assert.strictEqual(
+      currentURL(),
+      '/projects/mint-ec',
+      'we are on the project detail route',
+    );
+    assert
+      .dom(document.body)
+      .includesText('MINT EC', "the requested project's title is rendered");
+  });
+
+  test('visiting an unknown project id does not crash the app', async function (assert) {
+    await visit('/projects/does-not-exist');
+
+    assert
+      .dom(document.body)
+      .doesNotIncludeText(
+        'Missing translation',
+        'ember-intl translations are loaded',
+      );
+  });
+});


### PR DESCRIPTION
## Summary
- Only the home route had acceptance coverage before. Adds coverage for the projects list and detail routes.
- Exercises the real data-fetching path (`findAll`/`findRecord` against the static JSON API content) rather than a mocked one.
- Includes a check that visiting an unknown project id fails gracefully (no uncaught error, no broken translations) instead of throwing.

## Test plan
- [x] `pnpm test` passes locally (16/16 including the 3 new tests)
- [x] `pnpm lint:js` / prettier clean on the new file


---
_Generated by [Claude Code](https://claude.ai/code/session_01L5K9Ao2SFn8V9hdGF9drYC)_